### PR TITLE
upgrade docker base image to alpine:3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #     CGO_ENABLED=0 go build -a -tags netgo
 #     docker build --rm=true -t plugins/drone-rancher .
 
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.2
 RUN apk add --update \
   ca-certificates
 ADD drone-rancher /bin/


### PR DESCRIPTION
Need to fix this bug : https://github.com/gliderlabs/docker-alpine/issues/30
To be able to create a custom image with my CA root
