### PR TITLE
Added tag-filter param to support Continuous Delivery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ ENV GODEBUG=netdns=go
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 LABEL org.label-schema.version=latest
-LABEL org.label-schema.vcs-url="https://github.com/josmo/drone-rancher.git"
+LABEL org.label-schema.vcs-url="https://github.com/croudsupport/drone-rancher.git"
 LABEL org.label-schema.name="Drone Rancher"
-LABEL org.label-schema.vendor="Josmo"
+LABEL org.label-schema.vendor="Croud"
 
 ADD release/linux/amd64/drone-rancher /bin/
+
 ENTRYPOINT ["/bin/drone-rancher"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+
+export GOOS=linux
+export GOARCH=amd64
+export CGO_ENABLED=0
+
+
+go build -v -ldflags -a -o release/linux/amd64/drone-rancher
+docker build . --tag croudtech/drone-rancher:latest

--- a/build_amd64.sh
+++ b/build_amd64.sh
@@ -6,3 +6,4 @@ export CGO_ENABLED=0
 
 go build -v -ldflags -a -o release/linux/amd64/drone-rancher
 docker build . --tag croudtech/drone-rancher:latest
+docker push croudtech/drone-rancher:latest

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func run(c *cli.Context) error {
 		Secret:         c.String("secret-key"),
 		Service:        c.String("service"),
 		DockerImage:    c.String("docker-image"),
+		Tags:    c.String("docker-image-tags"),
 		StartFirst:     c.BoolT("start-first"),
 		Confirm:        c.Bool("confirm"),
 		Timeout:        c.Int("timeout"),

--- a/main.go
+++ b/main.go
@@ -64,6 +64,11 @@ func main() {
 			Value:    &cli.StringSlice{"latest"},
 			FilePath: ".tags",
 		},
+		cli.StringFlag{
+			Name:   "tag-filter",
+			Usage:  "only tags matching this value get deployed",
+			EnvVar: "PLUGIN_TAG_FILTER",
+		},
 		cli.BoolTFlag{
 			Name:   "start-first",
 			Usage:  "Start new container before stoping old",
@@ -112,6 +117,7 @@ func run(c *cli.Context) error {
 		Service:        c.String("service"),
 		DockerImage:    c.String("docker-image"),
 		Tags:    		c.StringSlice("docker-image-tags"),
+		TagFilter:    	c.String("tag-filter"),
 		StartFirst:     c.BoolT("start-first"),
 		Confirm:        c.Bool("confirm"),
 		Timeout:        c.Int("timeout"),

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
+	 "github.com/bradrydzewski/cli"
 	"log"
 	"os"
 )
@@ -28,6 +28,8 @@ func main() {
 	app.Usage = "rancher publish"
 	app.Action = run
 	app.Version = fmt.Sprintf("1.0.0+%s", build)
+
+	fmt.Println("hello world")
 
 	app.Flags = []cli.Flag{
 
@@ -56,12 +58,11 @@ func main() {
 			Usage:  "image to use",
 			EnvVar: "PLUGIN_DOCKER_IMAGE",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "docker-image-tags",
 			Usage:  "tag of docker image to use",
 			Value:    &cli.StringSlice{"latest"},
-			EnvVar: "PLUGIN_TAG,PLUGIN_TAGS",
-			FilePath: ".tags"
+			FilePath: ".tags",
 		},
 		cli.BoolTFlag{
 			Name:   "start-first",
@@ -110,7 +111,7 @@ func run(c *cli.Context) error {
 		Secret:         c.String("secret-key"),
 		Service:        c.String("service"),
 		DockerImage:    c.String("docker-image"),
-		Tags:    c.String("docker-image-tags"),
+		Tags:    		c.StringSlice("docker-image-tags"),
 		StartFirst:     c.BoolT("start-first"),
 		Confirm:        c.Bool("confirm"),
 		Timeout:        c.Int("timeout"),

--- a/main.go
+++ b/main.go
@@ -56,6 +56,13 @@ func main() {
 			Usage:  "image to use",
 			EnvVar: "PLUGIN_DOCKER_IMAGE",
 		},
+		cli.StringFlag{
+			Name:   "docker-image-tags",
+			Usage:  "tag of docker image to use",
+			Value:    &cli.StringSlice{"latest"},
+			EnvVar: "PLUGIN_TAG,PLUGIN_TAGS",
+			FilePath: ".tags"
+		},
 		cli.BoolTFlag{
 			Name:   "start-first",
 			Usage:  "Start new container before stoping old",

--- a/plugin.go
+++ b/plugin.go
@@ -36,7 +36,7 @@ func (p *Plugin) Exec() error {
 		p.DockerImage = fmt.Sprintf("docker:%s", p.DockerImage)
 		//if tags are supplied then pull the tag with the first one
 		if len(p.Tags) > 0 {
-			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+			reg, err := regexp.Compile("[^a-zA-Z0-9-_]+")
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/plugin.go
+++ b/plugin.go
@@ -16,7 +16,8 @@ type Plugin struct {
 	Secret         string
 	Service        string
 	DockerImage    string
-	Tags    		[]string
+	Tags    	   []string
+	TagFilter	   string
 	StartFirst     bool
 	Confirm        bool
 	Timeout        int
@@ -41,9 +42,14 @@ func (p *Plugin) Exec() error {
 				log.Fatal(err)
 			}
 			tag := reg.ReplaceAllString(p.Tags[0], "")
-
-			log.Info(fmt.Sprintf("pulling tag :%s", tag))
-			p.DockerImage = fmt.Sprintf("%s:%s", p.DockerImage, tag)
+			//if there is a tag filter then only allow matches - could be more sophisticated
+			if strings.EqualFold(p.TagFilter, tag) {
+				log.Info(fmt.Sprintf("pulling tag :%s", tag))
+				p.DockerImage = fmt.Sprintf("%s:%s", p.DockerImage, tag)
+			} else {
+				log.Info(fmt.Sprintf("Tag :%s does not match %s, skipping Rancher deploy", tag, p.TagFilter))
+				return nil
+			}
 		}
 	}
 	var wantedService, wantedStack string

--- a/plugin.go
+++ b/plugin.go
@@ -32,6 +32,10 @@ func (p *Plugin) Exec() error {
 
 	if !strings.HasPrefix(p.DockerImage, "docker:") {
 		p.DockerImage = fmt.Sprintf("docker:%s", p.DockerImage)
+		//need to check for other tags
+		//if !strings.HasSuffix(p.DockerImage, "docker:") {
+			p.DockerImage = fmt.Sprintf("%s:%s", p.DockerImage, p.Tags)
+		//}
 	}
 	var wantedService, wantedStack string
 	if strings.Contains(p.Service, "/") {

--- a/plugin.go
+++ b/plugin.go
@@ -15,6 +15,7 @@ type Plugin struct {
 	Secret         string
 	Service        string
 	DockerImage    string
+	Tags    string
 	StartFirst     bool
 	Confirm        bool
 	Timeout        int


### PR DESCRIPTION
I have added a tag-filter parameter to the plugin this will allow the same drone file to be used in a continuous delivery environment where only a single environment (integration in our case) will be published to. Any builds with a tag that does not match the filter will be skipped but not cause the build to fail. Realise this may require tweaking etc but we're using this functionality already so feel its useful.