### PR TITLE
Allow the use of RANCHER_URL to configure the plugin in place of PLUGIN_URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "url",
 			Usage:  "url to the rancher api",
-			EnvVar: "PLUGIN_URL",
+			EnvVar: "PLUGIN_URL, RANCHER_URL",
 		},
 		cli.StringFlag{
 			Name:   "access-key",


### PR DESCRIPTION
With Drone 0.6 onward, Drone has now migrated to a new secret system that allows us to specify our needed secrets using their name and have them injected as environment variables to the plugin, instead of having to call them via the environment pre-processor without clear difference between env-var and secrets.

Before 0.6, we became used to having both the URL and API keys setup as secrets so that we could update them without having to update our .drone.yml files. It seems that after our upgrade to Drone 0.8 we could no longer store our URL the same way we did before as `RANCHER_URL` is not a valid environment variable to configure this plugin.

Either needing to store it in the secret database as `plugin_url` or having to rename it every-time does not feel like a clean way to do what we want.

This changes introduce the possibility of inject it using:
```
secrets: [rancher_url,rancher_api_key,rancher_secret_key]
```
instead of having to rename the key each time as per this example
```
secrets:
  - source: rancher_url
    destination: plugin_url
  - source: rancher_api_key
    destination: rancher_api_key
  - source: rancher_secret_key
    destination: rancher_secret_key
```

I understand that not all configuration variable for the plugin should have a "rightly prefixed name" as most of them should not be stored as secrets but I feel like storing the URL with the API keys is a good use case when you want to be able to update them both at the same time: i.e. when doing a big migration.


PS: I apologize if this PR seems inappropriate as I did not open an issue first to discuss this change. As those changes are trivial and should only bring a quality of life improvement in people everyday use I did not think it would be needed.